### PR TITLE
Added the block wrapper

### DIFF
--- a/src/services/docxConverter.ts
+++ b/src/services/docxConverter.ts
@@ -56,9 +56,23 @@ function processFormattedText(text: string): TextRun[] {
 
 export async function convertMarkdownToDocx(markdownContent: string): Promise<Buffer> {
   try {
+    // Log sample of the markdown for debugging
+    logger.info('Input markdown sample:', {
+      sample: markdownContent.substring(0, Math.min(200, markdownContent.length)),
+      length: markdownContent.length
+    });
+
     // Parse markdown to tokens
     const tokens = marked.lexer(markdownContent);
     logger.info(`Parsed ${tokens.length} markdown tokens`);
+    
+    // Debug first few tokens to understand the structure
+    if (tokens.length > 0) {
+      logger.info('First token types:', {
+        types: tokens.slice(0, Math.min(5, tokens.length)).map(t => t.type)
+      });
+    }
+    
     const children: Paragraph[] = [];
     let lastTokenType: string | null = null;
     let consecutiveBreaks = 0;

--- a/src/services/googleDocs.ts
+++ b/src/services/googleDocs.ts
@@ -16,6 +16,15 @@ export async function convertMarkdownToGoogleDoc(
       sampleMarkdown: markdownContent.substring(0, 100) // Log sample of markdown for debugging
     });
     
+    // Strip markdown code block wrapper if present
+    if (markdownContent.startsWith('```markdown\n') && markdownContent.endsWith('```')) {
+      logger.info('Removing markdown code block wrapper');
+      markdownContent = markdownContent.substring('```markdown\n'.length, markdownContent.length - 3);
+    } else if (markdownContent.startsWith('```\n') && markdownContent.endsWith('```')) {
+      logger.info('Removing generic code block wrapper');
+      markdownContent = markdownContent.substring('```\n'.length, markdownContent.length - 3);
+    }
+    
     const auth = new google.auth.OAuth2();
     auth.setCredentials({
       access_token: accessToken,


### PR DESCRIPTION
feat: Add automatic code block wrapper removal

Add functionality to detect and strip markdown code block wrappers
from input content before processing. This improves compatibility
with raw markdown inputs that might be wrapped in code blocks
like ```markdown or ``` generic blocks.

This change ensures proper formatting of the converted Google Doc
by removing unnecessary wrapper syntax that would otherwise be
included in the final document.